### PR TITLE
chore: remove trailing space on tools.go

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -9,10 +9,3 @@ package tools
 import (
 	_ "github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs"
 )
-
-
-
-
-
-
-


### PR DESCRIPTION
- non functional cleanup